### PR TITLE
fix for targetVert and targetHeading for joystick

### DIFF
--- a/PilotAssistant/PilotAssistant.cs
+++ b/PilotAssistant/PilotAssistant.cs
@@ -464,8 +464,11 @@ namespace PilotAssistant
                     else if (GameSettings.YAW_RIGHT.GetKey())
                         hdg += bFineControl ? 0.04 / scale : 0.4 * scale;
                     else if (!GameSettings.AXIS_YAW.IsNeutral())
-                        hdg += (bFineControl ? 0.04 / scale : 0.4 * scale) * GameSettings.AXIS_YAW.GetAxis();
-
+                    {
+                        float axisYaw = GameSettings.AXIS_YAW.GetAxis();
+                        if (Math.Abs(axisYaw) > 0.000001f)
+                            hdg += (bFineControl ? 0.04 / scale : 0.4 * scale) * axisYaw;
+                    }
                     if (hdg < 0)
                         hdg += 360;
                     else if (hdg > 360)
@@ -473,6 +476,7 @@ namespace PilotAssistant
 
                     Utils.GetAsst(PIDList.HdgBank).SetPoint = hdg;
                     Utils.GetAsst(PIDList.BankToYaw).SetPoint = hdg;
+                    hdg = Math.Round(hdg, 9);
                     targetHeading = hdg.ToString();
                 }
 
@@ -487,7 +491,13 @@ namespace PilotAssistant
                     else if (GameSettings.PITCH_UP.GetKey())
                         vert += bFineControl ? 0.04 / scale : 0.4 * scale;
                     else if (!GameSettings.AXIS_PITCH.IsNeutral())
-                        vert += (bFineControl ? 0.04 / scale : 0.4 * scale) * GameSettings.AXIS_PITCH.GetAxis();
+                    {
+                        float axisPitch = GameSettings.AXIS_PITCH.GetAxis();
+                        if (Math.Abs(axisPitch) > 0.000001f)
+                        {
+                            vert += (bFineControl ? 0.04 / scale : 0.4 * scale) * axisPitch;
+                        }
+                    }
 
                     if (bAltitudeHold)
                     {
@@ -497,6 +507,7 @@ namespace PilotAssistant
                     else
                         Utils.GetAsst(PIDList.VertSpeed).SetPoint = vert;
 
+                    vert = Math.Round(vert, 9);
                     targetVert = vert.ToString();
                 }
 

--- a/PilotAssistant/PilotAssistant.cs
+++ b/PilotAssistant/PilotAssistant.cs
@@ -456,7 +456,7 @@ namespace PilotAssistant
             {
                 double scale = mod ? 10 : 1;
                 bool bFineControl = FlightInputHandler.fetch.precisionMode;
-                if (bHdgActive && (GameSettings.YAW_LEFT.GetKey() || GameSettings.YAW_RIGHT.GetKey() || !GameSettings.AXIS_YAW.IsNeutral()))
+                if (bHdgActive && (GameSettings.YAW_LEFT.GetKey() || GameSettings.YAW_RIGHT.GetKey() || (!GameSettings.AXIS_YAW.IsNeutral() && Math.Abs(GameSettings.AXIS_YAW.GetAxis()) > 0.000001f)))
                 {
                     double hdg = double.Parse(targetHeading);
                     if (GameSettings.YAW_LEFT.GetKey())
@@ -464,11 +464,8 @@ namespace PilotAssistant
                     else if (GameSettings.YAW_RIGHT.GetKey())
                         hdg += bFineControl ? 0.04 / scale : 0.4 * scale;
                     else if (!GameSettings.AXIS_YAW.IsNeutral())
-                    {
-                        float axisYaw = GameSettings.AXIS_YAW.GetAxis();
-                        if (Math.Abs(axisYaw) > 0.000001f)
-                            hdg += (bFineControl ? 0.04 / scale : 0.4 * scale) * axisYaw;
-                    }
+                        hdg += (bFineControl ? 0.04 / scale : 0.4 * scale) * GameSettings.AXIS_YAW.GetAxis();
+
                     if (hdg < 0)
                         hdg += 360;
                     else if (hdg > 360)
@@ -480,7 +477,7 @@ namespace PilotAssistant
                     targetHeading = hdg.ToString();
                 }
 
-                if (bVertActive && (GameSettings.PITCH_DOWN.GetKey() || GameSettings.PITCH_UP.GetKey() || !GameSettings.AXIS_PITCH.IsNeutral()))
+                if (bVertActive && (GameSettings.PITCH_DOWN.GetKey() || GameSettings.PITCH_UP.GetKey() || (!GameSettings.AXIS_PITCH.IsNeutral() && Math.Abs(GameSettings.AXIS_PITCH.GetAxis()) > 0.000001f)))
                 {
                     double vert = double.Parse(targetVert);
                     if (bAltitudeHold)
@@ -491,13 +488,7 @@ namespace PilotAssistant
                     else if (GameSettings.PITCH_UP.GetKey())
                         vert += bFineControl ? 0.04 / scale : 0.4 * scale;
                     else if (!GameSettings.AXIS_PITCH.IsNeutral())
-                    {
-                        float axisPitch = GameSettings.AXIS_PITCH.GetAxis();
-                        if (Math.Abs(axisPitch) > 0.000001f)
-                        {
-                            vert += (bFineControl ? 0.04 / scale : 0.4 * scale) * axisPitch;
-                        }
-                    }
+                        vert += (bFineControl ? 0.04 / scale : 0.4 * scale) * GameSettings.AXIS_PITCH.GetAxis();
 
                     if (bAltitudeHold)
                     {


### PR DESCRIPTION
This problem occurs when having a joystick.

When I use my joystick,
**GameSettings.AXIS_PITCH.IsNeutral()** always returns false,
and **GameSettings.AXIS_PITCH.GetAxis()** returns a very small float value.
The small value makes **targetVert** in GUI changes a little in every frame.

![pa](https://cloud.githubusercontent.com/assets/7445439/6600558/4d803db4-c84b-11e4-9aaf-47c9ca1b9a76.png)


And when input number from keyboard,
the inputed value takes effect before pressing the target button.
(Because **IsNeutral()** returns false.)
That's kind of anoying.

Same for **targetHeading**.

I change the code so **vert**/**heading** will not change
when axis value < **0.000001**.

I also round them, keep **9** decimals.
It should be precise enough,
and the text would not be longer than the TextField.
